### PR TITLE
change run user from root to nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ COPY . .
 RUN go install -a -tags netgo -installsuffix netgo -ldflags='-extldflags="static"' -v .
 
 FROM alpine
-COPY --from=build /go/bin/stub_container /
-COPY server.crt server.key /
 RUN apk --no-cache add --update curl
+
+# run as non-root user for kubernetes (especially pod security policy)
+# nobody:nobody
+USER 65534:65534
+COPY --chown=nobody:nobody --from=build /go/bin/stub_container /
+COPY --chown=nobody:nobody server.crt server.key /
+
 CMD ["/stub_container"]


### PR DESCRIPTION
# What
起動ユーザをrootからnobodyに変更する

# Why
KubernetesのPodSecurityPolicyやSecurityContextにおいて `runAsNonRoot` を有効化していると、rootで起動するイメージを使用したpodは起動に失敗してしまうため

# Additional Information
Dockerが起動できるところまでは確認済